### PR TITLE
Fix slice mutation in XOR brute force

### DIFF
--- a/basics/FindKeyToDecrypt/main.go
+++ b/basics/FindKeyToDecrypt/main.go
@@ -22,7 +22,9 @@ func main() {
 	var strBuilder strings.Builder
 
 	for key := 0; key <= 255; key++ {
-		decrypted := bytes
+		// create a copy so each iteration starts with the original bytes
+		decrypted := make([]byte, len(bytes))
+		copy(decrypted, bytes)
 
 		for i, j := range decrypted {
 			decrypted[i] = j ^ byte(key)


### PR DESCRIPTION
## Summary
- ensure XOR decryption loop starts from original bytes each iteration

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68405812f6ec832a8d74a9e99b65f3d2